### PR TITLE
Add SammaPix — WASM for AI image processing (alongside Photon, Squoosh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Welcome PR if you find some Awsome WebAssembly Applications 🤣
 
 - [[Squoosh] Replacing a hot path in your app's JavaScript with WebAssembly](https://developers.google.com/web/updates/2019/02/hotpath-with-wasm)
 
+- [[SammaPix] 27 browser-based image tools using WASM for AI background removal (RMBG-1.4 via ONNX Runtime Web) and JPEG XL encoding](https://www.sammapix.com)
+
 - [[Discourse] Faster (and smaller) uploads in Discourse with Rust, WebAssembly and MozJPEG](https://blog.discourse.org/2021/07/faster-user-uploads-on-discourse-with-rust-webassembly-and-mozjpeg/)
 
 - [[Zoom] Zoom on Web: WebAssembly SIMD, WebTransport, and WebCodecs](https://www.infoq.com/news/2020/08/zoom-web-chrome-apis/)


### PR DESCRIPTION
## SammaPix

[SammaPix](https://www.sammapix.com) uses WebAssembly for AI-powered image processing in the browser:

- **AI background removal**: RMBG-1.4 model running via ONNX Runtime Web (HuggingFace Transformers compiled to WASM)
- **JPEG XL encoding/decoding**: @jsquash/jxl WASM module for next-gen image format support

The WASM models download once (~40MB) and process entirely client-side. No server uploads.

Added to **Media** section alongside Photoshop, Figma, Photon, and Squoosh — all use WASM for media processing in the browser.