### PR TITLE
Add KubeStellar Console to Frontend Web App section

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Welcome PR if you find some Awsome WebAssembly Applications 🤣
 
 - [[Tokamak] SwiftUI-compatible framework for building browser apps with WebAssembly and native apps for other platforms](https://github.com/TokamakUI/Tokamak)
 
+- [[KubeStellar Console] AI-powered multi-cluster Kubernetes dashboard using SQLite WASM for persistent client-side caching](https://github.com/kubestellar/console)
+
 ### Scientific Calculator
 
 - [[kalker] Kallker is a feature-rich scientific calculator that runs in the browser](https://kalker.strct.net/)


### PR DESCRIPTION
Adds [KubeStellar Console](https://console.kubestellar.io) to the **Frontend Web App** section.

KubeStellar Console uses **SQLite WASM** (via sql.js compiled to WebAssembly) running in a Web Worker for persistent client-side caching. This enables instant data on revisit with stale-while-revalidate patterns, keeping the main thread jank-free.

- 🔗 Live: https://console.kubestellar.io
- 🧩 WASM usage: SQLite WASM in Web Worker for IndexedDB-backed cache- 
- 📜 License: Apache-2.0
- 🏛️ CNCF Sandbox project (under KubeStellar)