### PR TITLE
Add wine-assembly — Win32/Win98 apps in the browser, coded directly in WAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Welcome PR if you find some Awsome WebAssembly Applications 🤣
 
 ### Games
 
+- [[wine-assembly] Run unmodified Win32/Win98 PE executables — Pinball Space Cadet, SkiFree, FreeCell, Solitaire, Minesweeper, Winamp, mspaint — directly in the browser. The interpreter is coded directly in WebAssembly Text (no Rust/C compiler); guest binaries run as-is, no recompilation.](https://wine-assembly.berrry.app)
+
 - [[GLAS] GLAS = WebGL + Assembly Script(WASM);](https://dev.to/zoedreams/glas-webgl-assembly-script-wasm-i40)
 
 - [[白鹭引擎] WebAssembly 在白鹭引擎5.0中的实践](https://zhuanlan.zhihu.com/p/30513129)


### PR DESCRIPTION
Adds [wine-assembly](https://wine-assembly.berrry.app) to the **Games** section.

wine-assembly is a from-scratch x86 Windows 98 PE interpreter coded directly in WebAssembly Text. It runs unmodified Win32 executables — Pinball Space Cadet, SkiFree, the Microsoft Entertainment Pack (FreeCell, Solitaire, Minesweeper, Reversi, etc.), Winamp, mspaint — directly in a browser tab.

Unusual angle: the interpreter is written in WAT, not compiled from Rust/C/AssemblyScript — a Forth-style threaded-code x86 emulator with GDI→Canvas mapping.

Source: https://github.com/vgrichina/wine-assembly