### PR TITLE
Add IDPhotoSnap: browser-only passport photo tool (WASM + BRIA RMBG-1.4 + face-api.js)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Welcome PR if you find some Awsome WebAssembly Applications 🤣
 
 - [[SammaPix] 27 browser-based image tools using WASM for AI background removal (RMBG-1.4 via ONNX Runtime Web) and JPEG XL encoding](https://www.sammapix.com)
 
+- [[IDPhotoSnap] Browser-only passport and visa photo maker using WebAssembly. Background segmentation via BRIA RMBG-1.4 (ONNX), face landmark detection via face-api.js, geometric cropping via Canvas API. 100 countries, 248 document formats validated against 15+ official government sources (US State Dept, UK HMPO, Bundesdruckerei, Indian PSK, Chinese MFA COVA, etc.). Photo never leaves the device, verifiable in DevTools Network tab. Companion open dataset at github.com/whitetirocket/passport-photo-specs.](https://idphotosnap.com)
+
 - [[Discourse] Faster (and smaller) uploads in Discourse with Rust, WebAssembly and MozJPEG](https://blog.discourse.org/2021/07/faster-user-uploads-on-discourse-with-rust-webassembly-and-mozjpeg/)
 
 - [[Zoom] Zoom on Web: WebAssembly SIMD, WebTransport, and WebCodecs](https://www.infoq.com/news/2020/08/zoom-web-chrome-apis/)


### PR DESCRIPTION
Adds IDPhotoSnap to the Media section in 'Inside the browser'.

## Tech stack

- **WebAssembly** (Browser, no server uploads)
- **BRIA RMBG-1.4** (ONNX Runtime Web) for background segmentation - same pattern as SammaPix already in this section
- **face-api.js** (TF.js + WASM backend) for face landmark detection
- **Canvas API** for geometric cropping and JPEG export
- **jsPDF** for print-ready PDF output

## Why this fits

The Media section already includes SammaPix (RMBG-1.4 in browser via ONNX Runtime Web), Photon (image processing in WebAssembly), and similar tools. IDPhotoSnap is the passport-photo-specific application of the same architecture pattern.

## Scope

100 countries, 248 document formats validated against 15+ official government sources (US State Dept, UK HMPO, German Bundesdruckerei, Italian Polizia di Stato, Indian PSK + Sarathi, Chinese MFA COVA, Schengen Annex 11 ICAO 9303). The country specifications dataset is published separately as MIT-licensed open data at https://github.com/whitetirocket/passport-photo-specs for anyone building tools in this category.

## Verifiable claim

Photo never leaves the device - this is verifiable by inspecting the browser DevTools Network tab during the workflow. Zero photo uploads in the network log; only static assets and ML model weights.