### PR TITLE
Add PDF Mavericks to Online Productive Tools (40+ wasm-powered PDF tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Welcome PR if you find some Awsome WebAssembly Applications 🤣
 
 - [[Vizua] Free browser-based image tools — compress, resize, convert (WebP, AVIF, PNG, JPEG), remove background, upscale, OCR. 91 tools, all powered by WebAssembly; no server uploads.](https://vizua.io/)
 
+- [[PDF Mavericks] 40+ free browser-based PDF tools — compress, merge, split, sign, watermark, redact, OCR, convert. All processing via WebAssembly (pdf-lib + PDF.js); files never leave the device.](https://pdfmavericks.com/)
+
 ### Machine Learning
 
 - [[TensorFlow.js] Supercharging the TensorFlow.js WebAssembly backend with SIMD and multi-threading](https://blog.tensorflow.org/2020/09/supercharging-tensorflowjs-webassembly.html?m=1)


### PR DESCRIPTION
Adds [PDF Mavericks](https://pdfmavericks.com/) to the **Online Productive Tools** section.

PDF Mavericks is a free, no-account toolkit of 40+ PDF tools (compress, merge, split, sign, watermark, redact, OCR, convert) that runs entirely in the browser via WebAssembly. Core dependencies powered by wasm: pdf-lib for manipulation, PDF.js for rendering, @imgly/background-removal for image work. Files never leave the device — every operation is client-side.

Sits naturally alongside PDFGem (PDF) and Vizua (image) already listed in this section. Strong wasm-in-production angle: the entire toolkit ships as a static Next.js export with no backend, and the WebAssembly modules do all the heavy lifting in the browser.

Happy to adjust the entry text or shorten if it's too long for the section style.