### PR TITLE
Add ConvertiZen to Online Productive Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Welcome PR if you find some Awsome WebAssembly Applications 🤣
 - [[Vizua] Free browser-based image tools — compress, resize, convert (WebP, AVIF, PNG, JPEG), remove background, upscale, OCR. 91 tools, all powered by WebAssembly; no server uploads.](https://vizua.io/)
 
 - [[PDF Mavericks] 40+ free browser-based PDF tools — compress, merge, split, sign, watermark, redact, OCR, convert. All processing via WebAssembly (pdf-lib + PDF.js); files never leave the device.](https://pdfmavericks.com/)
+- - [ConvertiZen](https://convertizen.netlify.app) - Privacy-friendly document converter (PDF, Word, Excel, images) running entirely in the browser via WebAssembly. No file uploads, no server processing.
 
 ### Machine Learning
 


### PR DESCRIPTION
Adds ConvertiZen (https://convertizen.netlify.app) to the Online Productive Tools section.

ConvertiZen is a privacy-friendly document converter that runs entirely in the browser via WebAssembly (LibreOffice compiled to WASM). It converts PDF, Word, Excel, images and more with no file uploads and no server processing — files never leave the user's device.