### PR TITLE
Add Darkly photo editor to media section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Welcome PR if you find some Awsome WebAssembly Applications 🤣
 ## Inside the browser
 
 ### Media
+
+- [Darkly](https://demo.darkly.art) — An [open-source](https://github.com/darkly-art/darkly), WebGPU-powered photo editor and paint program for digital artists, written in Rust + WebAssembly.
+
 - [Remove Audio](https://remove-audio.com) — Strip audio from video files in the browser using WebAssembly and FFmpeg.wasm. No uploads, no account. Batch up to 20 files.
 
 - [IconKing](https://iconking.net) — Free browser-based Lottie animation tool. Preview .json/.lottie files, edit colors across all layers, and convert between Lottie JSON ↔ dotLottie formats. 100% client-side via WebAssembly — files never leave the browser.


### PR DESCRIPTION
Thanks for putting this list together. I added a new entry for [Darkly](https://darkly.art), a WebGPU-powered photo editor. Darkly is free and open-source and (shameless plug) made by me. 

https://github.com/user-attachments/assets/e0af23a9-0f42-430d-ad27-ffc26a3b2e9a

Demo: https://demo.darkly.art
Github: https://github.com/darkly-art/darkly