### PR TITLE
Add hushvert to Online Productive Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Welcome PR if you find some Awsome WebAssembly Applications 🤣
 
 - [[PDF Mavericks] 40+ free browser-based PDF tools — compress, merge, split, sign, watermark, redact, OCR, convert. All processing via WebAssembly (pdf-lib + PDF.js); files never leave the device.](https://pdfmavericks.com/)
 - [ConvertiZen](https://convertizen.netlify.app) - Privacy-friendly document converter (PDF, Word, Excel, images) running entirely in the browser via WebAssembly. No file uploads, no server processing.
+- [hushvert](https://hushvert.com) - Privacy-first file converter (images incl. HEIC/JPEG XL, PDF page operations, archives, audio, small video) running entirely in the browser via WebAssembly. No file uploads, no server processing.
 
 ### Machine Learning
 


### PR DESCRIPTION
Adds **hushvert** to the `Online Productive Tools` section, next to ConvertiZen.

It is a privacy-first file converter whose image, PDF, archive, audio and small-video conversions run entirely client-side via WebAssembly, so files never leave the browser - the same all-in-the-browser profile as the other tools in this section. The engine is open source (MIT) at https://github.com/hushvert/engine.

Disclosure: I maintain hushvert.
