### PR TITLE
Add Slay PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Welcome PR if you find some Awsome WebAssembly Applications 🤣
 - [[Vizua] Free browser-based image tools — compress, resize, convert (WebP, AVIF, PNG, JPEG), remove background, upscale, OCR. 91 tools, all powered by WebAssembly; no server uploads.](https://vizua.io/)
 
 - [[PDF Mavericks] 40+ free browser-based PDF tools — compress, merge, split, sign, watermark, redact, OCR, convert. All processing via WebAssembly (pdf-lib + PDF.js); files never leave the device.](https://pdfmavericks.com/)
+
+- [[Slay PDF] Free local PDF editor for splitting, merging, signing, resizing, posterising and editing PDFs. Runs in-browser with WebAssembly-powered PDF workflows; files stay on the device.](https://slaypdf.com/)
+
 - [ConvertiZen](https://convertizen.netlify.app) - Privacy-friendly document converter (PDF, Word, Excel, images) running entirely in the browser via WebAssembly. No file uploads, no server processing.
 
 ### Machine Learning


### PR DESCRIPTION
Adds Slay PDF to the Online Productive Tools section.

Slay PDF is a local browser PDF editor for splitting, merging, signing, resizing, posterising and editing PDFs. Its app metadata documents a modern-browser WebAssembly requirement, and the app exposes crawlable source and privacy links from the homepage.

Validation:
- Confirmed no existing Slay PDF PR in this repo.
- Confirmed https://slaypdf.com/ includes `browserRequirements: Requires a modern browser with WebAssembly and IndexedDB support.` in the WebApplication structured data.